### PR TITLE
Tournament match order added

### DIFF
--- a/frontend/src/UI/GameCanvas.tsx
+++ b/frontend/src/UI/GameCanvas.tsx
@@ -15,16 +15,15 @@ export const global_gameArea = {
 
 
 interface GameCanvasProps {
-  isLoggedIn: boolean;
+	onCanvasLogOut: () => void;
+	isLoggedIn: boolean;
 }
 
 
 // COMPONENT
-export const GameCanvas: React.FC<GameCanvasProps> = ({ isLoggedIn }) => {
+export const GameCanvas: React.FC<GameCanvasProps> = ({ isLoggedIn, onCanvasLogOut }) => {
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
   const prevTimestampRef = useRef<number>(0);
-
-  console.log('GameCanvas isLoggedIn: ', isLoggedIn);
 
   useEffect(() => {
     const canvas = canvasRef.current;
@@ -45,7 +44,7 @@ export const GameCanvas: React.FC<GameCanvasProps> = ({ isLoggedIn }) => {
 	  && !global_stateManager.getLoggedInStatus() && isLoggedIn)
 	  {
 		console.log('Game loop onStartScreenLoginFail');
-	//	onStartScreenLoginFail();
+		onCanvasLogOut();
 		global_stateManager.setLoggedInStatus(true); // Seems counter intuitive, but prevents unnecessary extra runs of this error handling in the future =)
 	  }
 

--- a/frontend/src/UI/Header.tsx
+++ b/frontend/src/UI/Header.tsx
@@ -9,7 +9,8 @@ import { useNavigate } from 'react-router-dom';
 
 interface HeaderProps {
   onHeaderLogOut: () => void;
-  onHeaderLogIn: () => void
+  onHeaderLogIn: () => void;
+  AppLogStatus: boolean;
 }
 
 export interface WindowManager {
@@ -17,7 +18,7 @@ export interface WindowManager {
   onDecline: () => void;
 }
 
-export const Header: React.FC<HeaderProps> = ( {onHeaderLogOut, onHeaderLogIn} ) => {
+export const Header: React.FC<HeaderProps> = ( {onHeaderLogOut, onHeaderLogIn, AppLogStatus} ) => {
   const [showRegistration, setShowRegistration] = useState(false);
   const [showLogin, setShowLogin] = useState(false);
   const [showSettings, setShowSettings] = useState(false);
@@ -26,7 +27,6 @@ export const Header: React.FC<HeaderProps> = ( {onHeaderLogOut, onHeaderLogIn} )
   const [loggedInUserData, setLoggedInUserData] = useState<User | null>(null);
   const navigate = useNavigate();
 
-  console.log('Header isLoggedIn state:', isLoggedIn);
 
  useEffect(() => {
   	const checkLoginStatus = async () => {
@@ -51,7 +51,7 @@ export const Header: React.FC<HeaderProps> = ( {onHeaderLogOut, onHeaderLogIn} )
   return () => {
     window.removeEventListener('loginStatusChanged', checkLoginStatus);
   };
-}, []);
+}, [AppLogStatus]);
 
   const handleLogout = () => {
 

--- a/frontend/src/components/App.tsx
+++ b/frontend/src/components/App.tsx
@@ -8,25 +8,30 @@ import { Instructions } from '../UI/Instructions';
 
 export default function App() {
 
-  const [isLoggedIn, setIsLoggedIn] = useState(false);
+	const [isLoggedIn, setIsLoggedIn] = useState(false);
 
-  const onLogOut = () =>
-  {
-	setIsLoggedIn(false);
-  }
+	const onLogOut = () =>
+	{
+		setIsLoggedIn(false);
+	}
 
-  const onLogIn = () =>
-  {
-	setIsLoggedIn(true);
-  }
+	const onLogIn = () =>
+	{
+		setIsLoggedIn(true);
+	}
+
+	const gameCanvasLogOut = () =>
+	{
+		setIsLoggedIn(false);
+	}
 
 
   return (
 	<>
-		<Header onHeaderLogOut={onLogOut} onHeaderLogIn={onLogIn} />
+		<Header onHeaderLogOut={onLogOut} onHeaderLogIn={onLogIn} AppLogStatus={isLoggedIn} />
 		<main className="pt-0">
 		<Routes>
-			<Route path="/" element={<GameCanvas isLoggedIn={isLoggedIn} />} />
+			<Route path="/" element={<GameCanvas isLoggedIn={isLoggedIn} onCanvasLogOut={gameCanvasLogOut} />} />
 			<Route path="/dashboard/:username" element={<DashboardWrapper isLoggedIn={isLoggedIn} />} />
 			<Route path="/playerlist" element={<PlayerList isLoggedIn={isLoggedIn} />} />
 			<Route path="/instructions" element={<Instructions />} />

--- a/frontend/src/game/Tournament.ts
+++ b/frontend/src/game/Tournament.ts
@@ -1,5 +1,5 @@
 import { GameStates, IGameState, } from "./GameStates";
-import { TEXT_PADDING } from "./Constants";
+import { DEEP_PURPLE, TEXT_PADDING } from "./Constants";
 import { User } from "../UI/UserManager";
 import { ReturnMainMenuButton } from "./EndScreen";
 import { BlockBattle } from "./BlockBattle";
@@ -55,6 +55,7 @@ export class Tournament implements IGameState
 	isSettingEndScreen: boolean;
 	isEndingTournament: boolean = false;
 	isLoggedIn: boolean = false;
+	gameOrder: [number, number][];
 	mouseMoveBound: (event: MouseEvent) => void;
     mouseClickBound: () => void;
 
@@ -73,6 +74,15 @@ export class Tournament implements IGameState
 		this.showLoadingText = false;
 		this.isSettingEndScreen = false;
 
+		this.gameOrder = [
+			[0, 1],
+			[2, 3],
+			[0, 2],
+			[1, 3],
+			[3, 0],
+			[2, 1]
+		];
+
 		let text1 = 'EXIT TOURNAMENT'; // Add a warning here that all tournament data will be lost
 		ctx.font = '25px arial' // GLOBAL USE OF CTX!!
 		const button1X = 20;
@@ -81,8 +91,8 @@ export class Tournament implements IGameState
 
 		let text2 = 'NEXT GAME';
 		ctx.font = '35px arial' // GLOBAL USE OF CTX!!
-		const button2X = (canvas.width / 2) - (ctx.measureText(text2).width / 2) - TEXT_PADDING;
-		const button2Y = (canvas.height / 2) - 20 - TEXT_PADDING + 240;
+		const button2X = (canvas.width * 0.75) - (ctx.measureText(text2).width / 2) - TEXT_PADDING;
+		const button2Y = (canvas.height / 2) - 20 - TEXT_PADDING + 200;
 		this.nextGameBtn = new NextGameBtn(this.ctx, button2X, button2Y, 'green', '#054d19', text2, 'white', '35px', 'arial');
 
 		setTimeout(() => {
@@ -279,7 +289,7 @@ export class Tournament implements IGameState
 	drawScoreBoard(ctx: CanvasRenderingContext2D)
 	{
 		const colW = 300;
-		const colH = 80;
+		const colH = 60;
 		let x = this.canvas.width / 2 - colW * 1.5;
 		let y = 170;
 		const padding = 45;
@@ -354,6 +364,49 @@ export class Tournament implements IGameState
 		}
 	}
 
+	drawMatchOrder()
+	{
+		let NameXCenter = this.canvas.width * 0.5;
+		let matchNumX = NameXCenter - 270;
+		let drawY = (this.canvas.height / 2) - 20 - TEXT_PADDING + 150;
+
+		for (let i = 0; i < 6; i++)
+		{
+			const player1TournamentId = this.gameOrder[i][0];
+			const player2TournamentId = this.gameOrder[i][1];
+			const player1Obj = this.playerArr.find(p => p.tournamentId === player1TournamentId);
+			const player2Obj = this.playerArr.find(p => p.tournamentId === player2TournamentId);
+
+			if (!player1Obj || !player2Obj)
+				continue ;
+
+			// Determine color
+			let color;
+			if (i < this.matchCounter)
+				color = 'gray';
+			else if (i === this.matchCounter)
+				color = 'green';
+			else
+				color = DEEP_PURPLE;
+
+			this.ctx.font = '30px arial';
+			this.ctx.fillStyle = color;
+
+			// Draw match number
+			const matchNumText = `Match ${i + 1}:`;
+			this.ctx.fillText(matchNumText, matchNumX, drawY);
+
+			// Draw matchup names
+			const matchupText = `${player1Obj.user.username} vs ${player2Obj.user.username}`;
+			const textLen = this.ctx.measureText(`${player1Obj.user.username} vs ${player2Obj.user.username}`).width;
+			const matchupX = NameXCenter - (textLen / 2);
+			this.ctx.fillText(matchupText, matchupX, drawY);
+
+			drawY += 38;
+
+		}
+	}
+
 	render(ctx: CanvasRenderingContext2D)
 	{
 
@@ -372,9 +425,13 @@ export class Tournament implements IGameState
 
 		if (!this.curState)
 		{
-			// Draw Header & Score Board
+			// Draw Header, Score Board and Match order
 			drawCenteredText(this.canvas, this.ctx, 'SCORE BOARD', '50px Impact', 'white', 100);
 			this.drawScoreBoard(ctx);
+
+			if (!this.isFinished)
+				this.drawMatchOrder();
+			
 	
 			// Draw Return button
 			this.returnMenuButton.draw(ctx);
@@ -393,25 +450,10 @@ export class Tournament implements IGameState
 			if (!this.isFinished)
 			{
 				this.nextGameBtn.draw(ctx);
-
-				const nextGameNum = `Game no. ${(this.matchCounter + 1).toString()}/6`;
-				const gameNumY = this.nextGameBtn.y + this.nextGameBtn.height + 50;
-				drawCenteredText(this.canvas, this.ctx, nextGameNum, '30px arial', 'white', gameNumY);
-
-	/*			const id1 = GameOrder[this.matchCounter][0];
-				const id2 = GameOrder[this.matchCounter][1];
-				const player1 = this.playerArr.find(player => player.id === id1);
-				const player2 = this.playerArr.find(player => player.id === id2);
-				let playerInfo = '';
-				if (player1 && player2)
-					playerInfo = `(${player1.user.username} vs ${player2.user.username})`;
-				const playerInfoY = gameNumY + 26;
-				drawCenteredText(this.canvas, this.ctx, playerInfo, '25px arial', 'red', playerInfoY); */
-
 			}
 			else
 			{
-				let y = (this.canvas.height / 2) - 20 - TEXT_PADDING + 270;
+				let y = (this.canvas.height / 2) - 20 - TEXT_PADDING + 220;
 
 				drawCenteredText(this.canvas, this.ctx, 'TOURNAMENT WINNER(s):', '50px Impact', 'green', y);
 				y += 40


### PR DESCRIPTION
1. I added a new feature to tournament UI: it now displays the match order (as subject suggests) under score board, so that players can clearly see who are gonna play against each other and when.
2.  I also made a small UX change: If game canvas is in Start Screen state and it loses connection to backend, it sends a message to Header component, which then changes it's buttons automatically to 'Logged Out mode'. This makes more sense, because if we have no connection to backend and DB, we need to log out the user as they can't do anything in app without the backend.