### PR TITLE
Switched to name mounts to comply with subject for rootless docker user.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,12 +31,8 @@ restart: stop start
 clean:
 	@echo "$(RED)Cleaning up Docker resources...$(RESET)"
 	docker compose -f $(COMPOSE_FILE) down -v
-	@echo "$(RED)Removing data directory contents...$(RESET)"
-	rm -rf data/*
-	touch data/.gitkeep
-	rm -rf certs/
-	rm -rf backend/certs
-	rm -rf frontend/certs
+	@echo "$(RED)Removing named volumes...$(RESET)"
+	docker volume ls -q --filter name=$$(basename $$(pwd)) | xargs -r docker volume rm || true
 
 fclean: clean
 	@echo "$(RED)Removing all unused Docker volumes...$(RESET)"
@@ -84,3 +80,4 @@ help:
 	@echo "  make logs-frontend - View frontend logs"
 	@echo "  make db       - View database tables"
 	@echo "  make help     - Show this help message"
+	@echo " docker run --rm -v ft_transcendence_ssl_certs:/certs alpine ls -la /certs " - View Certs

--- a/backend/config.js
+++ b/backend/config.js
@@ -1,9 +1,5 @@
-// Load environment variables from .env file if not in production
-if (process.env.NODE_ENV !== 'production') {
 	require('dotenv').config({ path: '../.env' });
-  }
-  
-  // Default config with environment variable fallbacks
+
   const config = {
 	port: process.env.BACKEND_PORT || 3443,
 	

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,12 +7,11 @@ services:
     ports:
       - "${BACKEND_PORT:-3443}:3443"
     volumes:
-      - ./backend:/app
-      - /app/node_modules
-      - ./data:/app/data
-      - ./certs:/app/certs
+      - backend_code:/app
+      - backend_node_modules:/app/node_modules
+      - app_data:/app/data
+      - ssl_certs:/app/certs
     environment:
-      - NODE_ENV=${NODE_ENV:-development}
       - JWT_SECRET=${JWT_SECRET:-dev_jwt_secret}
       - COOKIE_SECRET=${COOKIE_SECRET:-dev_cookie_secret}
       - DB_PATH=${DB_PATH:-/app/data/database.sqlite}
@@ -28,12 +27,19 @@ services:
     ports:
       - "${FRONTEND_PORT:-9000}:9000"
     volumes:
-      - ./frontend:/app
-      - /app/node_modules
-      - ./certs:/app/certs
+      - frontend_code:/app
+      - frontend_node_modules:/app/node_modules
+      - ssl_certs:/app/certs
     environment:
-      - NODE_ENV=${NODE_ENV:-development}
       - BACKEND_URL=${BACKEND_URL:-https://localhost:3443}
     depends_on:
       - backend
     restart: unless-stopped
+
+volumes:
+  backend_code:
+  frontend_code:
+  backend_node_modules:
+  frontend_node_modules:
+  app_data:
+  ssl_certs:


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/69f0cde1-2a46-49e5-a3a5-2949c0009bbb)
In page five of the subject PDF. We are not allowed to use bind-mounts if we are running docker rootless. So I changed to name volumes. 

With this change certs folder will no longer appear on our host machine. All volumes will be created in the docker container and will preserve between starts and stop but will no longer update on our local machine. 

This doesn't change our functionality at all. This can be tested by simply registering and then running make restart to restart the containers and then logging in again. If login is successful than this worked. 

Which I did test on the school's machine. 